### PR TITLE
Fallback to the initial page

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -23,8 +23,7 @@ dependencies:
   flutter_page_indicator:
     path: ../
 
-  transformer_page_view:
-    path: /Users/jzoom/SourceCode/transformer_page_view
+  transformer_page_view: ^0.1.6
 
 dev_dependencies:
   flutter_test:

--- a/lib/flutter_page_indicator.dart
+++ b/lib/flutter_page_indicator.dart
@@ -216,25 +216,22 @@ class _PageIndicatorState extends State<PageIndicator> {
   Paint _paint = new Paint();
 
   BasePainter _createPainer() {
+    final ctrl = widget.controller;
+    final page = ctrl.page ?? ctrl.initialPage?.toDouble() ?? 0.0;
+
     switch (widget.layout) {
       case PageIndicatorLayout.NONE:
-        return new NonePainter(
-            widget, widget.controller.page ?? 0.0, index, _paint);
+        return new NonePainter(widget, page, index, _paint);
       case PageIndicatorLayout.SLIDE:
-        return new SlidePainter(
-            widget, widget.controller.page ?? 0.0, index, _paint);
+        return new SlidePainter(widget, page, index, _paint);
       case PageIndicatorLayout.WARM:
-        return new WarmPainter(
-            widget, widget.controller.page ?? 0.0, index, _paint);
+        return new WarmPainter(widget, page, index, _paint);
       case PageIndicatorLayout.COLOR:
-        return new ColorPainter(
-            widget, widget.controller.page ?? 0.0, index, _paint);
+        return new ColorPainter(widget, page, index, _paint);
       case PageIndicatorLayout.SCALE:
-        return new ScalePainter(
-            widget, widget.controller.page ?? 0.0, index, _paint);
+        return new ScalePainter(widget, page, index, _paint);
       case PageIndicatorLayout.DROP:
-        return new DropPainter(
-            widget, widget.controller.page ?? 0.0, index, _paint);
+        return new DropPainter(widget, page, index, _paint);
       default:
         throw new Exception("Not a valid layout");
     }


### PR DESCRIPTION
If the `PageController` is initialized with a `initialPage`, the `flutter_page_indicator` will first try to retrieve that value. 